### PR TITLE
Make keywords case-insensitive

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -35,9 +35,9 @@ fun main(args: Array<String>) {
             while (true) {
                 print("] ")
                 val line = readLine()!!
-                if (line == "RUN" || line == "run") break
-                if (line == "END" || line == "end") break@outer
-                if (line == "LIST" || line == "list") {
+                if (line.lowercase() == "run") break
+                if (line.lowercase() == "end") break@outer
+                if (line.lowercase() == "list") {
                     lines.forEach { println(it) }
                     continue
                 }

--- a/src/main/kotlin/Scanner.kt
+++ b/src/main/kotlin/Scanner.kt
@@ -15,23 +15,14 @@ class Scanner(var text: String) {
 
     var keywords = mapOf(
         "print" to PRINT,
-        "PRINT" to PRINT,
         "if" to IF,
-        "IF" to IF,
         "goto" to GOTO,
-        "GOTO" to GOTO,
         "input" to INPUT,
-        "INPUT" to INPUT,
         "let" to LET,
-        "LET" to LET,
         "gosub" to GOSUB,
-        "GOSUB" to GOSUB,
         "return" to RETURN,
-        "RETURN" to RETURN,
         "end" to END,
-        "END" to END,
         "then" to THEN,
-        "THEN" to THEN,
     )
 
     private var tokens = mutableListOf<Token>()
@@ -178,7 +169,7 @@ class Scanner(var text: String) {
             advance()
         }
         val text = text.substring(start, current)
-        val type = keywords[text] ?: VAR
+        val type = keywords[text.lowercase()] ?: VAR
         addToken(type)
     }
 }


### PR DESCRIPTION
In the original Tiny BASIC allowed things like `PrInT`, so it's fitting that we do that too.