### PR TITLE
Gracefully quit on EOF in interactive mode

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -34,7 +34,7 @@ fun main(args: Array<String>) {
             val lines = mutableListOf<String>()
             while (true) {
                 print("] ")
-                val line = readLine()!!
+                val line = readLine() ?: break@outer
                 if (line == "RUN" || line == "run") break
                 if (line == "END" || line == "end") break@outer
                 if (line == "LIST" || line == "list") {


### PR DESCRIPTION
Before we crashed with a NullPointerException when encountering an EOF in interactive mode, now we quit just like if the user typed END.