### PR TITLE
General codegen optimisations

### DIFF
--- a/src/main/kotlin/Compiler.kt
+++ b/src/main/kotlin/Compiler.kt
@@ -344,11 +344,7 @@ class Compiler(private val ast: ProgramStmt) : Expr.Visitor<Unit>, Stmt.Visitor 
 
         // set line number to next line
         labels[nextLine].let {
-            if (it != null) {
-                methodVisitor.visitLdcInsn(nextLine)
-                methodVisitor.visitFieldInsn(Opcodes.PUTSTATIC, className, "lineNumber", "I")
-                methodVisitor.visitJumpInsn(Opcodes.GOTO, codeLabel)
-            } else {
+            if (it == null) {
                 methodVisitor.visitInsn(Opcodes.RETURN)
             }
         }

--- a/src/main/kotlin/Compiler.kt
+++ b/src/main/kotlin/Compiler.kt
@@ -230,9 +230,14 @@ class Compiler(private val ast: ProgramStmt) : Expr.Visitor<Unit>, Stmt.Visitor 
     }
 
     override fun visitGotoStmt(stmt: GotoStmt) {
-        stmt.line.accept(this)
-        methodVisitor.visitFieldInsn(Opcodes.PUTSTATIC, className, "lineNumber", "I")
-        methodVisitor.visitJumpInsn(Opcodes.GOTO, codeLabel)
+        if (stmt.line is NumberLiteral) {
+            val labelOfLine = labels[stmt.line.value.toInt()]
+            methodVisitor.visitJumpInsn(Opcodes.GOTO, labelOfLine)
+        } else {
+            stmt.line.accept(this)
+            methodVisitor.visitFieldInsn(Opcodes.PUTSTATIC, className, "lineNumber", "I")
+            methodVisitor.visitJumpInsn(Opcodes.GOTO, codeLabel)
+        }
     }
 
     override fun visitInputStmt(stmt: InputStmt) {


### PR DESCRIPTION
Feel free to cherry pick this when done.

- [x] set `lineNumber` on declaration
- [x] make print statements codegen better
- [x] make `GOTO`s use actual `goto`s in some cases
- [x] remove unneccessary breaks from switch statement
